### PR TITLE
Expose locks from pg_locks

### DIFF
--- a/collector/locks.go
+++ b/collector/locks.go
@@ -1,0 +1,78 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	locksSubsystem = "locks"
+	locksQuery     = `
+SELECT datname
+     , locktype
+		 , mode
+		 , granted
+		 , count(*)
+FROM pg_locks JOIN pg_database ON pg_locks.database=pg_database.oid
+GROUP BY datname, locktype, mode, granted /*postgres_exporter*/
+`
+)
+
+type locksCollector struct {
+	locks *prometheus.Desc
+}
+
+func init() {
+	registerCollector("locks", defaultEnabled, NewLocksCollector)
+}
+
+// NewLocksCollector returns a new Collector exposing data from pg_locks
+func NewLocksCollector() (Collector, error) {
+	return &locksCollector{
+		locks: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, locksSubsystem, "table"),
+			"Number of locks by datname, locktype, mode and granted",
+			[]string{"datname", "locktype", "mode", "granted"},
+			nil,
+		),
+	}, nil
+}
+
+func (c *locksCollector) Update(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	rows, err := db.QueryContext(ctx, locksQuery)
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	var datname, locktype, mode string
+	var granted bool
+	var count float64
+
+	for rows.Next() {
+		if err := rows.Scan(&datname, &locktype, &mode, &granted, &count); err != nil {
+			return err
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			c.locks,
+			prometheus.GaugeValue,
+			count,
+			datname,
+			locktype,
+			mode,
+			strconv.FormatBool(granted),
+		)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is a small addition of lock metrics taken from the pg_locks table.
pg_locks only contains information about table level locks (as opposed
to row level) and so we expose the postgres_locks_table metric.

Locks are grouped by:

- datname: for querying against a specific database,
- locktype: to identify whether affecting relation, tuple, etc
- mode: indicating the potential to conflict
- granted: whether the lock is waiting or granted

These stats alone don't give much of a useful view into the locks taken
but they do provide a starting point, if only to allow detection of many
blocked locks. What we should do in future is aggregate stats from a
logged stream of events in order to track how long locks waited- this
would paint a much better picture of database health.