### PR TITLE
Metrics about the oldest transaction and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Prometheus exporter for PostgreSQL server metrics.
 | postgres_stat_activity_connections | Number of current connections in their current state | datname, state |
 | postgres_up | Whether the Postgres server is up | |
 | postgres_in_recovery | Whether Postgres is in recovery | |
+| postgres_stat_activity_oldest_xact_timestamp | Oldest transaction timestamp (epoch) | |
+| postgres_stat_activity_oldest_backend_timestamp| Oldest backend timestamp (epoch) |
 
 ### Running
 

--- a/collector/stat_activity.go
+++ b/collector/stat_activity.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -10,6 +11,7 @@ import (
 const (
 	// Subsystem
 	statActivitySubsystem = "stat_activity"
+
 	// Scrape query
 	statActivityQuery = `
 WITH states AS (
@@ -27,23 +29,46 @@ SELECT datname, state, COALESCE(count, 0) as count
        FROM pg_stat_activity GROUP BY datname, state
 	   ) AS activity
 USING (datname, state) /*postgres_exporter*/`
+
+	// Oldest transaction timestamp
+	statActivityCollectorXactQuery = `
+SELECT min(xact_start)
+  FROM pg_stat_activity
+  WHERE state IN ('idle in transaction', 'active') /*postgres_exporter*/`
+
+	// Oldest backend timestamp
+	statActivityCollectorBackendStartQuery = `select min(backend_start) FROM pg_stat_activity /*postgres_exporter*/`
 )
 
 type statActivityCollector struct {
 	connections *prometheus.Desc
+	xact        *prometheus.Desc
+	backend     *prometheus.Desc
 }
 
 func init() {
 	registerCollector("stat_activity", defaultEnabled, NewStatActivityCollector)
 }
 
-// NewStatActivityColletor returns a new Collector expsoing postgres pg_stat_activity
+// NewStatActivityCollector returns a new Collector exposing postgres pg_stat_activity
 func NewStatActivityCollector() (Collector, error) {
 	return &statActivityCollector{
 		connections: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, statActivitySubsystem, "connections"),
 			"Number of current connections in their current state",
 			[]string{"datname", "state"},
+			nil,
+		),
+		xact: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statActivitySubsystem, "oldest_xact_timestamp"),
+			"The oldest transaction started timestamp",
+			nil,
+			nil,
+		),
+		backend: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statActivitySubsystem, "oldest_backend_timestamp"),
+			"The oldest backend started timestamp",
+			nil,
 			nil,
 		),
 	}, nil
@@ -71,6 +96,23 @@ func (c *statActivityCollector) Update(ctx context.Context, db *sql.DB, ch chan<
 	if err != nil {
 		return err
 	}
+
+	var oldestTx, oldestBackend time.Time
+	err = db.QueryRowContext(ctx, statActivityCollectorXactQuery).Scan(&oldestTx)
+	if err != nil {
+		return err
+	}
+
+	// postgres_stat_activity_oldest_xact_timestamp
+	ch <- prometheus.MustNewConstMetric(c.xact, prometheus.GaugeValue, float64(oldestTx.UTC().Unix()))
+
+	err = db.QueryRowContext(ctx, statActivityCollectorBackendStartQuery).Scan(&oldestBackend)
+	if err != nil {
+		return err
+	}
+
+	// postgres_stat_activity_oldest_backend_timestamp
+	ch <- prometheus.MustNewConstMetric(c.backend, prometheus.GaugeValue, float64(oldestBackend.UTC().Unix()))
 
 	return nil
 }


### PR DESCRIPTION
This PR adds two new metrics:
- postgres_stat_activity_oldest_xact_timestamp Epoch time of the oldest
transaction
- postgres_stat_activity_oldest_backend_timestamp Epoch time of the
oldest backend