### PR TITLE
Add metrics oldest query and oldest snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+---
+language: go
+go:
+  - "1.10"
+
+jobs:
+  include:
+    - stage: build
+      script: make
+    - stage: dep-ensure
+      script:
+        - go get -u github.com/golang/dep/cmd/dep
+        - dep ensure -v -no-vendor -dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [full changelog](https://github.com/rnaveiras/postgres_exporter/compare/v0.1.4...master)
 
-* Add `oldest_query_active_seconds` metric ([#10](https://github.com/rnaveiras/postgres_exporter/pull/10))
+* Add metrics oldest query and oldest snapshot ([#10](https://github.com/rnaveiras/postgres_exporter/pull/10))
 
 ## Version 0.1.4 / 2018-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+[full changelog](https://github.com/rnaveiras/postgres_exporter/compare/v0.1.4...master)
+
+* Add `oldest_query_active_seconds` metric ([#10](https://github.com/rnaveiras/postgres_exporter/pull/10))
+
 ## Version 0.1.4 / 2018-03-20
 
 [full changelog](https://github.com/rnaveiras/postgres_exporter/compare/v0.1.3...v0.1.4)

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -36,7 +36,8 @@
     "internal/sanitize",
     "pgio",
     "pgproto3",
-    "pgtype"
+    "pgtype",
+    "stdlib"
   ]
   revision = "da3231b0b66e2e74cdb779f1d46c5e958ba8be27"
   version = "v3.1.0"
@@ -121,6 +122,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1cdd1bd2a4d7276d52f72ff0f801f3123a1ca139b0faabea69125c7e22dd87a9"
+  inputs-digest = "22dac169f7932d41c2f2540d529d70fdd6c09cb58c068cb39023127a885f4db0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,10 +22,6 @@
 
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/lib/pq"
-
-[[constraint]]
   name = "github.com/prometheus/client_golang"
   version = "0.8.0"
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,12 @@ Prometheus exporter for PostgreSQL server metrics.
 | postgres_in_recovery | Whether Postgres is in recovery | |
 | postgres_stat_activity_oldest_xact_timestamp | Oldest transaction timestamp (epoch) | |
 | postgres_stat_activity_oldest_backend_timestamp| Oldest backend timestamp (epoch) |
+| postgres_stat_activity_oldest_query_active_seconds| Oldest query in running
+state |
 
-### Running
+### Run
 
-export DATA_SOURCE_NAME="postgres://localhost:5432/postgres"
-./postgres_exporter
+```
+./postgres_exporter \
+    --db.data-source="application_name=postgres_exporter user=postgres host=/var/run/postgresql"
+```

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Prometheus exporter for PostgreSQL server metrics.
 | postgres_stat_activity_connections | Number of current connections in their current state | datname, state |
 | postgres_up | Whether the Postgres server is up | |
 | postgres_in_recovery | Whether Postgres is in recovery | |
-| postgres_stat_activity_oldest_xact_timestamp | Oldest transaction timestamp (epoch) | |
 | postgres_stat_activity_oldest_backend_timestamp| Oldest backend timestamp (epoch) |
+| postgres_stat_activity_oldest_xact_seconds | Oldest transaction | |
 | postgres_stat_activity_oldest_query_active_seconds| Oldest query in running
+| postgres_stat_activity_oldest_snapshot_seconds| Oldest Snapshot
 state |
 
 ### Run


### PR DESCRIPTION
## New metrics:
- postgres_stat_activity_oldest_query_active_seconds 
- postgres_stat_activity_oldest_snapshot_seconds

## Change metric name:
- postgres_stat_activity_oldest_xact_timestamp to postgres_stat_activity_oldest_xact_seconds
