### PR TITLE
Use package `pgx` directly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [full changelog](https://github.com/rnaveiras/postgres_exporter/compare/v0.1.4...master)
 
+* Use package `pgx` directly
+    ([#13](https://github.com/rnaveiras/postgres_exporter/pull/13))
 * Add collector `stat_replication`
     ([#12](https://github.com/rnaveiras/postgres_exporter/pull/12))
 * Add metrics oldest query and oldest snapshot ([#10](https://github.com/rnaveiras/postgres_exporter/pull/10))

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -36,8 +36,7 @@
     "internal/sanitize",
     "pgio",
     "pgproto3",
-    "pgtype",
-    "stdlib"
+    "pgtype"
   ]
   revision = "da3231b0b66e2e74cdb779f1d46c5e958ba8be27"
   version = "v3.1.0"
@@ -122,6 +121,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "22dac169f7932d41c2f2540d529d70fdd6c09cb58c068cb39023127a885f4db0"
+  inputs-digest = "1cdd1bd2a4d7276d52f72ff0f801f3123a1ca139b0faabea69125c7e22dd87a9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ Prometheus exporter for PostgreSQL server metrics.
 
 ```
 ./postgres_exporter \
-    --db.data-source="application_name=postgres_exporter user=postgres host=/var/run/postgresql"
+    --db.data-source="user=postgres host=/var/run/postgresql"
 ```

--- a/collector/locks.go
+++ b/collector/locks.go
@@ -14,7 +14,7 @@ const (
 SELECT datname
      , locktype
      , mode
-	 , granted
+     , granted
      , count(*)::float
   FROM pg_locks
   JOIN pg_database ON pg_locks.database=pg_database.oid

--- a/collector/stat_database.go
+++ b/collector/stat_database.go
@@ -13,7 +13,7 @@ const (
 	// Scrape query
 	statDatabaseQuery = `
 SELECT datname
-     , numbackends::float,
+     , numbackends::float
      , tup_returned::float
      , tup_fetched::float
      , tup_inserted::float

--- a/collector/stat_replication.go
+++ b/collector/stat_replication.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"net"
 
 	"github.com/jackc/pgx"
 	"github.com/prometheus/client_golang/prometheus"
@@ -48,7 +49,8 @@ func (c *statReplicationCollector) Update(ctx context.Context, db *pgx.Conn, ch 
 	}
 	defer rows.Close()
 
-	var applicationName, clientAddr, state, syncState string
+	var applicationName, state, syncState string
+	var clientAddr net.IP
 	var pgXlogLocationDiff float64
 
 	for rows.Next() {
@@ -66,7 +68,7 @@ func (c *statReplicationCollector) Update(ctx context.Context, db *pgx.Conn, ch 
 			prometheus.GaugeValue,
 			pgXlogLocationDiff,
 			applicationName,
-			clientAddr,
+			clientAddr.String(),
 			state,
 			syncState)
 	}

--- a/collector/stat_replication.go
+++ b/collector/stat_replication.go
@@ -2,8 +2,8 @@ package collector
 
 import (
 	"context"
-	"database/sql"
 
+	"github.com/jackc/pgx"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -41,8 +41,8 @@ func NewStatReplicationCollector() (Collector, error) {
 	}, nil
 }
 
-func (c *statReplicationCollector) Update(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
-	rows, err := db.QueryContext(ctx, statReplicatonLagBytes)
+func (c *statReplicationCollector) Update(ctx context.Context, db *pgx.Conn, ch chan<- prometheus.Metric) error {
+	rows, err := db.QueryEx(ctx, statReplicatonLagBytes, nil)
 	if err != nil {
 		return err
 	}

--- a/collector/stat_user_tables.go
+++ b/collector/stat_user_tables.go
@@ -2,11 +2,10 @@ package collector
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
+	"github.com/jackc/pgx"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
 )
 
 // The Statistics Collector
@@ -21,17 +20,59 @@ import (
 const (
 	// Subsystem
 	statUserTablesSubsystem = "stat_user_tables"
+
 	// Scrape query
-	statUserTablesQuery = `SELECT schemaname, relname, seq_scan, last_analyze FROM pg_all_user_tables`
+	statUserTablesQuery = `
+SELECT schemaname
+     , relname
+     , seq_scan::float
+     , seq_tup_read::float
+     , idx_scan::float
+     , idx_tup_fetch::float
+     , n_tup_ins::float
+     , n_tup_upd::float
+     , n_tup_del::float
+     , n_tup_hot_upd::float
+     , n_live_tup::float
+     , n_dead_tup::float
+     , n_mod_since_analyze::float
+     , COALESCE(last_analyze, make_timestamptz(1970,01,01,0,0,0.0,'UTC')) AS last_analyze
+     , COALESCE(last_autoanalyze, make_timestamptz(1970,01,01,0,0,0.0,'UTC')) AS last_autoanalyze
+     , COALESCE(last_vacuum, make_timestamptz(1970,01,01,0,0,0.0,'UTC')) AS last_vacuum
+     , COALESCE(last_autovacuum, make_timestamptz(1970,01,01,0,0,0.0,'UTC')) AS last_autovacuum
+     , vacuum_count::float
+     , autovacuum_count::float
+     , analyze_count::float
+     , autoanalyze_count::float
+  FROM pg_stat_user_tables
+ WHERE schemaname != 'information_schema' /*postgres_exporter*/`
 )
 
 type statUserTablesCollector struct {
-	seqScan     *prometheus.Desc
-	lastAnalyze *prometheus.Desc
+	seqScan          *prometheus.Desc
+	seqTupRead       *prometheus.Desc
+	idxScan          *prometheus.Desc
+	idxTupFetch      *prometheus.Desc
+	nTupIns          *prometheus.Desc
+	nTupUpd          *prometheus.Desc
+	nTupDel          *prometheus.Desc
+	nTupHotUpd       *prometheus.Desc
+	nLiveTup         *prometheus.Desc
+	nDeadTup         *prometheus.Desc
+	nModSinceAnalyze *prometheus.Desc
+	lastAnalyze      *prometheus.Desc
+	lastAutoAnalyze  *prometheus.Desc
+	lastVacuum       *prometheus.Desc
+	lastAutoVacuum   *prometheus.Desc
+	vacuumCount      *prometheus.Desc
+	autovacuumCount  *prometheus.Desc
+	analyzeCount     *prometheus.Desc
+	autoanalyzeCount *prometheus.Desc
 }
 
 func init() {
-	registerCollector("stat_user_tables", defaultDisabled, NewStatUserTablesCollector)
+	//TODO
+	// registerCollector("stat_user_tables", defaultEnabled, NewStatUserTablesCollector)
 }
 
 // NewStatUserTablesCollector returns a new Collector exposing postgres pg_stat_database view
@@ -43,35 +84,197 @@ func NewStatUserTablesCollector() (Collector, error) {
 			[]string{"schemaname", "relname"},
 			nil,
 		),
+		seqTupRead: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "seq_tup_read_total"),
+			"Number of live rows fetched by sequential scans",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		idxScan: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "idx_scan_total"),
+			"Number of index scans initiated on this table",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		idxTupFetch: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "idx_tup_fetch_total"),
+			"Number of live rows fetched by index scans",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		nTupIns: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "n_tup_ins_total"),
+			"Number of rows inserted",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		nTupUpd: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "n_tup_upd_total"),
+			"Number of rows updated",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		nTupDel: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "n_tup_del_total"),
+			"Number of rows deleted",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		nTupHotUpd: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "n_tup_hot_upd"),
+			"Number of rows HOT updated (i.e., with no separate index update required)",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		nLiveTup: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "n_live_tup"),
+			"Estimated number of live rows",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		nDeadTup: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "n_dead_tup"),
+			"Estimated number of dead rows",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		nModSinceAnalyze: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "n_mod_since_analyze"),
+			"Estimated number of rows modified since this table was last analyzed",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
 		lastAnalyze: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "timestamp_last_analyze_seconds"),
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "last_analyze_timestamp"),
 			"Last time at which this table was manually analyzed",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		lastAutoAnalyze: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "last_autoanalyze_timestamp"),
+			"Last time at which this table was analyzed by the autovacuum daemon",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		lastVacuum: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "last_vacuum_timestamp"),
+			"Last time at which this table was manually vacuumed (not counting VACUUM FULL)",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		lastAutoVacuum: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "last_autovacuum_timestamp"),
+			"Last time at which this table was vacuumed by the autovacuum daemon",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		vacuumCount: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "vacuum_total"),
+			"Number of times this table has been manually vacuumed (not counting VACUUM FULL)",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		autovacuumCount: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "autovacuum_total"),
+			"Number of times this table has been vacuumed by the autovacuum daemon",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		analyzeCount: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "analyze_total"),
+			"Number of times this table has been manually analyzed",
+			[]string{"schemaname", "relname"},
+			nil,
+		),
+		autoanalyzeCount: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, statUserTablesSubsystem, "autoanalyze_total"),
+			"Number of times this table has been analyzed by the autovacuum daemon",
 			[]string{"schemaname", "relname"},
 			nil,
 		),
 	}, nil
 }
 
-func (c *statUserTablesCollector) Update(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
-	rows, err := db.QueryContext(ctx, statUserTablesQuery)
+func (c *statUserTablesCollector) Update(ctx context.Context, db *pgx.Conn, ch chan<- prometheus.Metric) error {
+	rows, err := db.QueryEx(ctx, statUserTablesQuery, nil)
 	if err != nil {
 		return err
 	}
 	defer rows.Close()
 
 	var schemaname, relname string
-	var seqScan float64
-	var lastAnalyze time.Time
+	var seqScan, seqTupRead, idxScan, idxTupFetch, nTupIns, nTupUpd, nTupDel,
+		nTupHotUpd, nLiveTup, nDeadTup, nModSinceAnalyze, vacuumCount,
+		autovacuumCount, analyzeCount, autoanalyzeCount float64
+	var lastAnalyze, lastVacuum, lastAutoAnalyze, lastAutoVacuum time.Time
 	for rows.Next() {
-		if err := rows.Scan(&schemaname, &relname, &seqScan, &lastAnalyze); err != nil {
+		if err := rows.Scan(&schemaname,
+			&relname,
+			&seqScan,
+			&seqTupRead,
+			&idxScan,
+			&idxTupFetch,
+			&nTupIns,
+			&nTupUpd,
+			&nTupDel,
+			&nTupHotUpd,
+			&nLiveTup,
+			&nDeadTup,
+			&nModSinceAnalyze,
+			&lastAnalyze,
+			&lastAutoAnalyze,
+			&lastVacuum,
+			&lastAutoVacuum,
+			&vacuumCount,
+			&autovacuumCount,
+			&analyzeCount,
+			&autoanalyzeCount); err != nil {
 			return err
 		}
 
-		log.Infoln("analyze", lastAnalyze)
 		// postgres_stat_user_tables_seq_scan
 		ch <- prometheus.MustNewConstMetric(c.seqScan, prometheus.CounterValue, seqScan, schemaname, relname)
-		// postgres_stat_user_tables_timestamp_last_analyze_seconds
+		// postgres_stat_user_tables_seq_tup_read
+		ch <- prometheus.MustNewConstMetric(c.seqTupRead, prometheus.CounterValue, seqTupRead, schemaname, relname)
+
+		// postgres_stat_user_tables_idx_scan_total
+		ch <- prometheus.MustNewConstMetric(c.idxScan, prometheus.CounterValue, idxScan, schemaname, relname)
+		// postgres_stat_user_tables_idx_fetch_total
+		ch <- prometheus.MustNewConstMetric(c.idxTupFetch, prometheus.CounterValue, idxTupFetch, schemaname, relname)
+
+		// postgres_stat_user_tables_n_tup_in_total
+		ch <- prometheus.MustNewConstMetric(c.nTupIns, prometheus.CounterValue, nTupIns, schemaname, relname)
+		// postgres_stat_user_tables_n_tup_upd_total
+		ch <- prometheus.MustNewConstMetric(c.nTupUpd, prometheus.CounterValue, nTupUpd, schemaname, relname)
+		// postgres_stat_user_tables_n_tup_del_total
+		ch <- prometheus.MustNewConstMetric(c.nTupDel, prometheus.CounterValue, nTupDel, schemaname, relname)
+		// postgres_stat_user_tables_n_tup_hot_upd_total
+		ch <- prometheus.MustNewConstMetric(c.nTupHotUpd, prometheus.CounterValue, nTupHotUpd, schemaname, relname)
+
+		// postgres_stat_user_tables_n_live_tup
+		ch <- prometheus.MustNewConstMetric(c.nLiveTup, prometheus.GaugeValue, nLiveTup, schemaname, relname)
+		// postgres_stat_user_tables_n_dead_tup
+		ch <- prometheus.MustNewConstMetric(c.nDeadTup, prometheus.GaugeValue, nDeadTup, schemaname, relname)
+		// postgres_stat_user_tables_n_mod_since_analyze
+		ch <- prometheus.MustNewConstMetric(c.nModSinceAnalyze, prometheus.GaugeValue, nModSinceAnalyze, schemaname, relname)
+
+		// postgres_stat_user_tables_last_analyze_timestamp
 		ch <- prometheus.MustNewConstMetric(c.lastAnalyze, prometheus.GaugeValue, float64(lastAnalyze.UTC().Unix()), schemaname, relname)
+		// postgres_stat_user_tables_last_autoanalyze_timestamp
+		ch <- prometheus.MustNewConstMetric(c.lastAutoAnalyze, prometheus.GaugeValue, float64(lastAutoAnalyze.UTC().Unix()), schemaname, relname)
+		// postgres_stat_user_tables_last_vacuum_timestamp
+		ch <- prometheus.MustNewConstMetric(c.lastVacuum, prometheus.GaugeValue, float64(lastVacuum.UTC().Unix()), schemaname, relname)
+		// postgres_stat_user_tables_last_autovacuum_timestamp
+		ch <- prometheus.MustNewConstMetric(c.lastAutoVacuum, prometheus.GaugeValue, float64(lastAutoVacuum.UTC().Unix()), schemaname, relname)
+
+		// postgres_stat_user_tables_vacuum_total
+		ch <- prometheus.MustNewConstMetric(c.vacuumCount, prometheus.CounterValue, vacuumCount, schemaname, relname)
+		// postgres_stat_user_tables_autovacuum_total
+		ch <- prometheus.MustNewConstMetric(c.autovacuumCount, prometheus.CounterValue, autovacuumCount, schemaname, relname)
+		// postgres_stat_user_tables_analyze_total
+		ch <- prometheus.MustNewConstMetric(c.analyzeCount, prometheus.CounterValue, analyzeCount, schemaname, relname)
+		// postgres_stat_user_tables_autovacuum_total
+		ch <- prometheus.MustNewConstMetric(c.autoanalyzeCount, prometheus.CounterValue, autoanalyzeCount, schemaname, relname)
 	}
 
 	err = rows.Err()


### PR DESCRIPTION
Drop use of `database/sql`, instead  use [pgx](https://github.com/jackc/pgx).

Allow us to manage the connections directly setting the ground floor to use the improvements in stat_user_tables collector on different database connections.