### PR TITLE
Don't exit during startup if database is unavailable

### DIFF
--- a/postgres_exporter.go
+++ b/postgres_exporter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 
 	// _ "net/http/pprof"
 
@@ -103,7 +102,6 @@ func main() {
 	conn, err = pgx.Connect(connConfig)
 	if err != nil {
 		log.Errorln("Error openning connection to database:", err)
-		os.Exit(-1)
 		//TODO: handle retries
 	}
 


### PR DESCRIPTION
We should add background retries so that postgres_exporter ends up connecting once the
database is up but we shouldn't fail hard on the database being down. If we do, we end up
having to manage the monitor and the database in lock step.