### PR TITLE
Add support cascade replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+[full changelog](https://github.com/rnaveiras/postgres_exporter/compare/master...v0.2.1)
+
+* Add support cascade replication
+    ([#18](https://github.com/rnaveiras/postgres_exporter/pull/18))
+
 ## Version 0.2.1 / 2018-06-12
 
 [full changelog](https://github.com/rnaveiras/postgres_exporter/compare/v0.2.0...v0.2.1)

--- a/collector/stat_replication.go
+++ b/collector/stat_replication.go
@@ -18,7 +18,8 @@ SELECT application_name
      , client_addr
      , state
      , sync_state
-     , pg_xlog_location_diff(pg_current_xlog_location(), replay_location)::float AS pg_xlog_location_diff
+     , (case when pg_is_in_recovery() then pg_xlog_location_diff(pg_last_xlog_receive_location(), replay_location)::float
+                                      else pg_xlog_location_diff(pg_current_xlog_location(), replay_location)::float end) AS pg_xlog_location_diff
   FROM pg_stat_replication /*postgres_exporter*/`
 )
 


### PR DESCRIPTION
pg_current_xlog_location() returns the current transaction log write
location but it only works if postgresql is not in recovery.

pg_last_xlog_receive_location() get last transaction log location
received and synced to disk by streaming replication. While the
streaming is in progress this will increase monotonically. This function
can be called on any replica meanwhile is in recovery.

We use the latter to calculate the different in bytes bettween the last
transaction log location recived by the replica and the replay_location
reported by the cascade replica.