### PR TITLE
Improve replication metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [full changelog](https://github.com/rnaveiras/postgres_exporter/compare/master...v0.2.1)
 
+* Improve replication metrics
+* ([#20](https://github.com/rnaveiras/postgres_exporter/pull/20))
 * Use go-kit/log ([#19](https://github.com/rnaveiras/postgres_exporter/pull/19))
 * Add support cascade replication
     ([#18](https://github.com/rnaveiras/postgres_exporter/pull/18))

--- a/collector/stat_replication.go
+++ b/collector/stat_replication.go
@@ -14,13 +14,17 @@ const (
 
 	// Scrape query
 	statReplicatonLagBytes = `
-SELECT application_name
-     , client_addr
-     , state
-     , sync_state
-     , (case when pg_is_in_recovery() then pg_xlog_location_diff(pg_last_xlog_receive_location(), replay_location)::float
-                                      else pg_xlog_location_diff(pg_current_xlog_location(), replay_location)::float end) AS pg_xlog_location_diff
-  FROM pg_stat_replication /*postgres_exporter*/`
+WITH pg_replication AS (
+  SELECT application_name
+       , client_addr
+       , state
+       , sync_state
+       , (case when pg_is_in_recovery() THEN pg_xlog_location_diff(pg_last_xlog_receive_location(), replay_location)::float
+                                        ELSE pg_xlog_location_diff(pg_current_xlog_location(), replay_location)::float end)
+                                        AS pg_xlog_location_diff
+    FROM pg_stat_replication
+     )
+SELECT * FROM pg_replication WHERE pg_xlog_location_diff != null /*postgres_exporter*/`
 )
 
 type statReplicationCollector struct {


### PR DESCRIPTION
Ignore null pg_xlog_location_diff

When pg_basebackup is running in stream mode, it opens a second
connection to the server and starts streaming the transaction log in
parallel while running the backup. In both connections (state=backup and
state=streaming) the pg_log_location_diff is null