### PR TITLE
Amend replication metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.2.3 / 2018-08-29
+
+[full changelog](https://github.com/rnaveiras/postgres_exporter/compare/v0.2.2...v0.2.3)
+
+* Amend replication metric ([#21](https://github.com/rnaveiras/postgres_exporter/pull/21))
+
 ## Version 0.2.2 / 2018-08-27
 
 [full changelog](https://github.com/rnaveiras/postgres_exporter/compare/v0.2.1...v0.2.2)

--- a/collector/stat_replication.go
+++ b/collector/stat_replication.go
@@ -19,12 +19,18 @@ WITH pg_replication AS (
        , client_addr
        , state
        , sync_state
-       , (case when pg_is_in_recovery() THEN pg_xlog_location_diff(pg_last_xlog_receive_location(), replay_location)::float
-                                        ELSE pg_xlog_location_diff(pg_current_xlog_location(), replay_location)::float end)
-                                        AS pg_xlog_location_diff
+       , ( CASE when pg_is_in_recovery()
+           THEN pg_xlog_location_diff(pg_last_xlog_receive_location(), replay_location)::float
+           ELSE pg_xlog_location_diff(pg_current_xlog_location(), replay_location)::float
+		   END
+	     ) AS pg_xlog_location_diff
     FROM pg_stat_replication
-     )
-SELECT * FROM pg_replication WHERE pg_xlog_location_diff != null /*postgres_exporter*/`
+)
+/* When pg_basebackup is running in stream mode, it opens a second connection
+to the server and starts streaming the transaction log in parallel while
+running the backup. In both connections (state=backup and state=streaming) the
+pg_log_location_diff is null and it requires to be exclude */
+SELECT * FROM pg_replication WHERE pg_xlog_location_diff IS NOT NULL /*postgres_exporter*/`
 )
 
 type statReplicationCollector struct {


### PR DESCRIPTION
Amend replication metrics to properly ignore nulls

This is a bug fixed for the changes introduced in #20 