### PR TITLE
Add additional info metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
+## Version 0.4.0 / 2019-05-19
+
+[full changelog](https://github.com/rnaveiras/postgres_exporter/compare/v0.3.0...v0.4.0)
+
+* Add additional info metrics ([#26](https://github.com/rnaveiras/postgres_exporter/pull/26))
+
 ## Version 0.3.0 / 2019-05-12
 
-[full changelog](https://github.com/rnaveiras/postgres_exporter/compare/v0.3.0...v0.2.5)
+[full changelog](https://github.com/rnaveiras/postgres_exporter/compare/v0.2.5...v0.3.0)
 
 * Change connection model ([#24](https://github.com/rnaveiras/postgres_exporter/pull/24))
-* Add version suppor ([#25](https://github.com/rnaveiras/postgres_exporter/pull/25))
+* Add version support ([#25](https://github.com/rnaveiras/postgres_exporter/pull/25))
 
 ## Version 0.2.5 / 2019-03-07
 

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -93,6 +93,7 @@ func NewExporter(ctx context.Context, logger kitlog.Logger, connConfig pgx.ConnC
 			NewLocksScraper(),
 			NewStatActivityScraper(),
 			NewStatArchiverScraper(),
+			NewStatBgwriterScraper(),
 			NewStatDatabaseScraper(),
 			NewStatReplicationScraper(),
 			NewStatUserTablesScraper(),

--- a/collector/info.go
+++ b/collector/info.go
@@ -2,17 +2,24 @@ package collector
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
-	isInRecoveryQuery = `SELECT pg_is_in_recovery()::int /*postgres_exporter*/`
+	isInRecoveryQuery   = `SELECT pg_is_in_recovery()::int /*postgres_exporter*/`
+	isInBackupQuery     = `SELECT pg_is_in_backup()::int /*postgres_exporter*/`
+	startTimeQuery      = `SELECT pg_postmaster_start_time() /*postgres_exporter*/`
+	configLoadTimeQuery = `SELECT pg_conf_load_time() /*postgres_exporter*/`
 )
 
 type infoScraper struct {
-	isInRecovery *prometheus.Desc
+	isInRecovery   *prometheus.Desc
+	isInBackup     *prometheus.Desc
+	startTime      *prometheus.Desc
+	configLoadTime *prometheus.Desc
 }
 
 // NewInfoScraper returns a new Scraper exposing postgres info
@@ -24,6 +31,24 @@ func NewInfoScraper() Scraper {
 			nil,
 			nil,
 		),
+		isInBackup: prometheus.NewDesc(
+			"postgres_is_in_backup",
+			"True if an on-line exclusive backup is still in progress.",
+			nil,
+			nil,
+		),
+		startTime: prometheus.NewDesc(
+			"postgres_start_time_seconds",
+			"Postgres start time, in seconds since the unix epoch.",
+			nil,
+			nil,
+		),
+		configLoadTime: prometheus.NewDesc(
+			"postgres_config_last_load_time_seconds",
+			"Timestamp of the last configuration reload",
+			nil,
+			nil,
+		),
 	}
 }
 
@@ -32,13 +57,32 @@ func (c *infoScraper) Name() string {
 }
 
 func (c *infoScraper) Scrape(ctx context.Context, conn *pgx.Conn, version Version, ch chan<- prometheus.Metric) error {
-	var recovery int64
+	var recovery, backup int64
+	var startTime, configLoadTime time.Time
 
 	if err := conn.QueryRowEx(ctx, isInRecoveryQuery, nil).Scan(&recovery); err != nil {
 		return err
 	}
-	// postgres_recovery
+	// postgres_is_in_recovery
 	ch <- prometheus.MustNewConstMetric(c.isInRecovery, prometheus.GaugeValue, float64(recovery))
+
+	if err := conn.QueryRowEx(ctx, isInBackupQuery, nil).Scan(&backup); err != nil {
+		return err
+	}
+	// postgres_is_in_backup
+	ch <- prometheus.MustNewConstMetric(c.isInBackup, prometheus.GaugeValue, float64(backup))
+
+	if err := conn.QueryRowEx(ctx, startTimeQuery, nil).Scan(&startTime); err != nil {
+		return err
+	}
+	// postgres_start_time_seconds
+	ch <- prometheus.MustNewConstMetric(c.startTime, prometheus.GaugeValue, float64(startTime.UTC().Unix()))
+
+	if err := conn.QueryRowEx(ctx, configLoadTimeQuery, nil).Scan(&configLoadTime); err != nil {
+		return err
+	}
+	// postgres_config_last_load_time_seconds
+	ch <- prometheus.MustNewConstMetric(c.configLoadTime, prometheus.GaugeValue, float64(configLoadTime.UTC().Unix()))
 
 	return nil
 }


### PR DESCRIPTION
- Bugfix: Enabled StatBgwriterScraper, it was disabled in previous
release
- Add `postgres_config_last_load_time_seconds`. Timestamp of the last configuration reload
- Add `postgres_start_time_seconds`. Postgres start time, in seconds since the unix epoch
- Add `postgres_is_in_backup`. True if an on-line exclusive backup is still in progress