### PR TITLE
Amend oldest query active and oldest snapshot

### DIFF
--- a/collector/stat_activity.go
+++ b/collector/stat_activity.go
@@ -43,16 +43,13 @@ SELECT EXTRACT(EPOCH FROM age(clock_timestamp(), coalesce(min(xact_start), curre
 	statActivityScraperActiveQuery = `
 SELECT EXTRACT(EPOCH FROM age(clock_timestamp(), coalesce(min(query_start), clock_timestamp())))
   FROM pg_stat_activity
- WHERE state='active' /*postgres_exporter*/`
+ WHERE state='active' AND backend_type = 'client backend' /*postgres_exporter*/`
 
 	// Oldest Snapshot
-	// ignore when backend_xid is null, so we exclude autovacuumn, autoanalyze
-	// and other maintenance tasks
 	statActivityScraperOldestSnapshotQuery = `
 SELECT EXTRACT(EPOCH FROM age(clock_timestamp(), coalesce(min(query_start), clock_timestamp())))
   FROM pg_stat_activity
- WHERE backend_xmin IS NOT NULL
-   AND backend_xid  IS NOT NULL /*postgres_exporter*/`
+ WHERE backend_xmin IS NOT NULL /*postgres_exporter*/`
 )
 
 type statActivityScraper struct {


### PR DESCRIPTION
`postgres_stat_activity_oldest_snapshot_seconds `was reporting incorrect
values because in most of the cases backend_xid was null, but the query
was having a backend_xmin that prevent vacuum