### PR TITLE
Support postgresql 12/13

### DIFF
--- a/collector/stat_database.go
+++ b/collector/stat_database.go
@@ -27,7 +27,8 @@ SELECT datname
      , deadlocks::float
      , temp_files::float
      , temp_bytes::float
-  FROM pg_stat_database /*postgres_exporter*/`
+  FROM pg_stat_database
+  WHERE datname IS NOT NULL /*postgres_exporter*/`
 )
 
 type statDatabaseScraper struct {


### PR DESCRIPTION
After the addition of new counters in `pg_stat_database` to track
checksums failures, `pg_stat_database` will also now show available
statistics for shared objects (such as the `pg_database`), in a new row
with `datid` valued to 0 and `datname` valued to NULL

Ignore statistics for shared objects.

Full context here:

https://github.com/postgres/postgres/commit/77bd49adba4711b4497e7e39a5ec3a9812cbd52a
https://github.com/postgres/postgres/commit/6b9e875f7286d8535bff7955e5aa3602e188e436

Signed-off-by: Raúl Naveiras <me@raulnaveiras.com>
