### PR TITLE
Support reading connection information from PG* envvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,30 @@ Prometheus exporter for PostgreSQL server metrics.
 
 ### Run
 
+#### Passing in a libpq connection string
+
 ```
 ./postgres_exporter \
     --db.data-source="user=postgres host=/var/run/postgresql"
+```
+
+#### Using the PG* environment variables
+
+- Set the [libpq PG* envvars](https://www.postgresql.org/docs/current/libpq-envars.html) like so:
+
+```
+export PGHOST=/var/run/postgresql
+export PGUSER=postgres
+```
+
+- or in a [pgservicefile](https://www.postgresql.org/docs/current/libpq-pgservice.html)
+
+```
+export PGSERVICEFILE=/var/run/cloudsql/pg_service.conf
+```
+
+- then, invoke the `postgres_exporter` binary
+
+```
+./postgres_exporter
 ```

--- a/postgres_exporter.go
+++ b/postgres_exporter.go
@@ -20,16 +20,12 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-const (
-	defaultDSN string = "user=postgres host=/var/run/postgresql"
-)
-
 var handlerLock sync.Mutex
 
 var (
 	listenAddress = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default("0.0.0.0:9187").String()
 	metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-	dataSource    = kingpin.Flag("db.data-source", "libpq compatible data source").Default(defaultDSN).String()
+	dataSource    = kingpin.Flag("db.data-source", "libpq compatible data source, e.g `user=postgres host=/var/run/postgresql`. Leave this blank to read connection information from PG* environment variables").String()
 	logLevel      = kingpin.Flag("log.level", "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]").Default("info").String()
 )
 


### PR DESCRIPTION
> ParseConfig creates a ConnConfig from a connection string.
> ParseConfig handles all options that pgconn.ParseConfig does

[pgx.ParseConfig docs](https://pkg.go.dev/github.com/jackc/pgx/v4#ParseConfig)

> ParseConfig builds a *Config with similar behavior to the PostgreSQL standard C library libpq. It uses the same defaults
> as libpq (e.g. port=5432) and understands most PG* environment variables. ParseConfig closely matches the parsing behavior
> of libpq.
> connString may either be in URL format or keyword = value format (DSN style)...
> connString also may be empty to only read from the environment.

[pgconn.ParseConfig docs](https://pkg.go.dev/github.com/jackc/pgconn#ParseConfig)

In order to support the postgres_exporter reading connection information from the PG* envvars, we remove the default connection
string in the `--db.data-source` flag.

This means that `pgx` (& consequently `pgconn`) would now attempt to read the connection information by default from the environment variables.